### PR TITLE
[showcase] Investigating `max-old-space-size` settings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 
 commands:
   serverless_deploy:
-    description: '(Mock) Deploy'
+    description: 'Deploy using the ServerlessFramework Orb'
     parameters:
       stage:
         type: string
@@ -15,17 +15,17 @@ commands:
     steps:
       - checkout
       - sls/setup
-      - run:
+      - run: &sls_check
           name: checking Serverless tool
           command: |
             command -v sls
             command -v serverless
-      - run:
+      - run: &sls_print_default
           name: print Serverles project config
           command: |
             cd src/services/core
             SLS_DEBUG=* sls print --stage << parameters.stage >>
-      - run:
+      - run: &sls_print_nodeoptions
           # Interestingly, setting "max-old-space-size" via NODE_OPTIONS env var causes `sls` to exit 4,
           # even for `sls print` command, before we even discuss about deployment.
           environment:
@@ -37,14 +37,41 @@ commands:
             cd src/services/core
             SLS_DEBUG=* sls print --stage << parameters.stage >>
 
+  serverless_deploy_without_orb:
+    description: 'Deploy without the ServerlessFramework Orb'
+    parameters:
+      stage:
+        type: string
+        default: 'development'
+    steps:
+      - checkout
+      - run:
+          name: Install Serverless via NPM
+          command: |
+            sudo npm install -g serverless
+      - run:
+          <<: *sls_check
+      - run:
+          <<: *sls_print_default
+      - run:
+          <<: *sls_print_nodeoptions
+
 jobs:
-  deploy_development:
+  deploy_development_with_orb:
     executor: sls/default
     steps:
       - serverless_deploy:
+          stage: 'development'
+  deploy_development_without_orb:
+    executor: sls/default
+    steps:
+      - serverless_deploy_without_orb:
           stage: 'development'
 
 workflows:
   main:
     jobs:
-      - deploy_development
+      - deploy_development_with_orb
+  alternative:
+    jobs:
+      - deploy_development_without_orb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,77 +1,77 @@
 version: 2.1
 
 orbs:
-  node: circleci/node@4.7.0
   sls: circleci/serverless-framework@1.0.1
+  aws-cli: circleci/aws-cli@2.0.3
 
-
-commands:
+jobs:
   serverless_deploy:
-    description: 'Deploy using the ServerlessFramework Orb'
     parameters:
       stage:
         type: string
         default: 'development'
+      use-serverless-framework-orb:
+        type: boolean
+        default: true
+      node-options:
+        description: 'value to set for NODE_OPTIONS environment variable'
+        type: string
+        default: ''
+    # NOTE: this is essentially cimg/python:3.8-node currently (as of Oct 21, 2021).
+    # See https://circleci.com/developer/orbs/orb/circleci/serverless-framework#executors-default
+    # We can just declare the specific docker image as well.
+    executor: sls/default
     steps:
       - checkout
-      - sls/setup
-      - run: &sls_check
-          name: checking Serverless tool
+      - when:
+          condition: << parameters.use-serverless-framework-orb >>
+          steps:
+            - sls/setup
+      - when:
+          condition:
+            not: << parameters.use-serverless-framework-orb >>
+          steps:
+            - run:
+                name: Install Serverless via NPM
+                command: |
+                  sudo npm install -g serverless
+            # Install AWS CLI, and set up our AWS credentials.
+            # This is the same step taken by the ServerlessFramework orb for AWS deployments
+            - aws-cli/setup
+      - run:
+          name: verify ServerlessFramework CLI tool
           command: |
             command -v sls
             command -v serverless
-      - run: &sls_print_default
-          name: print Serverles project config
-          command: |
-            cd src/services/core
-            SLS_DEBUG=* sls print --stage << parameters.stage >>
-      - run: &sls_print_nodeoptions
-          # Interestingly, setting "max-old-space-size" via NODE_OPTIONS env var causes `sls` to exit 4,
-          # even for `sls print` command, before we even discuss about deployment.
+      - run:
           environment:
-            # max-old-space-size: 2GB
-            # trace-exit: allows us to print the Node/V8 error stacktrace
-            NODE_OPTIONS: '--max-old-space-size=2048 --trace-exit'
-          name: print Serverles project config again, with NODE_OPTIONS env var
+            NODE_OPTIONS: '<< parameters.node-options >>'
+            SLS_DEBUG: '*'
+          name: verify ServerlessFramework project
           command: |
             cd src/services/core
-            SLS_DEBUG=* sls print --stage << parameters.stage >>
-
-  serverless_deploy_without_orb:
-    description: 'Deploy without the ServerlessFramework Orb'
-    parameters:
-      stage:
-        type: string
-        default: 'development'
-    steps:
-      - checkout
+            sls print --stage << parameters.stage >>
       - run:
-          name: Install Serverless via NPM
+          environment:
+            NODE_OPTIONS: '<< parameters.node-options >>'
+            SLS_DEBUG: '*'
+          name: Deploy ServerlessFramework project
           command: |
-            sudo npm install -g serverless
-      - run:
-          <<: *sls_check
-      - run:
-          <<: *sls_print_default
-      - run:
-          <<: *sls_print_nodeoptions
-
-jobs:
-  deploy_development_with_orb:
-    executor: sls/default
-    steps:
-      - serverless_deploy:
-          stage: 'development'
-  deploy_development_without_orb:
-    executor: sls/default
-    steps:
-      - serverless_deploy_without_orb:
-          stage: 'development'
+            cd src/services/core
+            sls deploy --stage << parameters.stage >>
 
 workflows:
   main:
     jobs:
-      - deploy_development_with_orb
+      # We expect this to fail due to odd behaviour (exit 4) when setting max-old-space-size for sls binary.
+      # Interestingly, setting "max-old-space-size" via NODE_OPTIONS env var causes `sls` to exit 4,
+      # even for `sls print` command, before we even discuss about deployment.
+      - serverless_deploy:
+          use-serverless-framework-orb: true
+          node-options: '--max-old-space-size=4096 --trace-exit'
   alternative:
     jobs:
-      - deploy_development_without_orb
+      # We expect this to pass with max-old-space-size set via NODE_OPTIONS env var going through
+      - serverless_deploy:
+          use-serverless-framework-orb: false
+          node-options: '--max-old-space-size=4096 --trace-exit'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,10 +26,16 @@ commands:
             cd src/services/core
             SLS_DEBUG=* sls print --stage << parameters.stage >>
       - run:
-          name: deploy
+          # Interestingly, setting "max-old-space-size" via NODE_OPTIONS env var causes `sls` to exit 4,
+          # even for `sls print` command, before we even discuss about deployment.
+          environment:
+            # max-old-space-size: 2GB
+            # trace-exit: allows us to print the Node/V8 error stacktrace
+            NODE_OPTIONS: '--max-old-space-size=2048 --trace-exit'
+          name: print Serverles project config again, with NODE_OPTIONS env var
           command: |
             cd src/services/core
-            SLS_DEBUG=* sls deploy --stage << parameters.stage >>
+            SLS_DEBUG=* sls print --stage << parameters.stage >>
 
 jobs:
   deploy_development:

--- a/src/services/core/handler.js
+++ b/src/services/core/handler.js
@@ -5,7 +5,7 @@ module.exports.hello = async (event) => {
     statusCode: 200,
     body: JSON.stringify(
       {
-        message: 'Go Serverless v1.0! Your function executed successfully!',
+        message: 'Awesome, your function executed successfully!',
         input: event,
       },
       null,


### PR DESCRIPTION
### Description

This PR is to showcase the oddity when we set max-old-space-size for Node, via `NODE_OPTIONS`, when running `sls` commands.
Mainly, when using the installed `sls` standalone binary (via ServerlessFramework orb), we see [an odd exit code 4, with this stacktace](https://app.circleci.com/pipelines/github/kelvintaywl/circleci-serverless-example/17/workflows/422f1805-1c26-43d2-82b9-6ad277e06c94/jobs/23):

```
(node:100) WARNING: Exited the environment with code 4
    at exit (internal/process/per_thread.js:172:13)
    at _compile (pkg/prelude/bootstrap.js:1429:29)
    at Module._extensions..js (internal/modules/cjs/loader.js:1218:10)
    at Module.load (internal/modules/cjs/loader.js:1047:32)
    at Module._load (internal/modules/cjs/loader.js:935:14)
    at Module.require (internal/modules/cjs/loader.js:1087:19)
    at require (pkg/prelude/bootstrap.js:1338:31)
    at require (internal/modules/cjs/helpers.js:73:18)
    at /snapshot/serverless/lib/classes/Variables.js:7:20
    at _compile (pkg/prelude/bootstrap.js:1433:22)

Exited with code exit status 4
```

Looking at that stacktrace, it seems to be a `pkg` issue.
From what I can gather, the `sls` binary installed by CircleCI's ServerlessFramework is done [as a standalone binary](https://www.serverless.com/framework/docs/getting-started#install-as-a-standalone-binary).
> I believe ServerlessFramework CLI uses [Vercel's `pkg` tool](https://github.com/vercel/pkg) to package the CLI.

From existing GitHub issues, there seem to be unresolved cases of `pkg` exiting on exit code 4.
- https://github.com/vercel/pkg/issues/1217
- https://github.com/vercel/pkg/issues/921

In particularly, this comment from a GitHub user seems to explain the situation, but not the solution:
https://github.com/vercel/pkg/issues/921#issuecomment-637841339


### Solution

Hence, I provided an alternative to deploying, should you need to explicitly set max-old-space-size when deploying with `sls`.
The solution is basically to forgo the `sls` standalone binary for now (i.e., not using the ServerlessFramework orb), and explicitly install the ServerlessFramework CLI **via NPM** and AWS CLI instead.

You can see the differences in this PR's CI build status:

| Workflow | Job | Build Status | Spec |
| --- | --- | --- | --- |
|  `main` | `serverless-deploy-1` | ❌  [see build](https://circleci.com/gh/kelvintaywl/circleci-serverless-example/23?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)  | `NODE_OPTIONS:--max-old-space-size=4096`, use ServerlessFramework Orb |
| `alternative` | `serverless-deploy-2` | ✅ [see build](https://circleci.com/gh/kelvintaywl/circleci-serverless-example/24?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) | `NODE_OPTIONS:--max-old-space-size=4096`, install ServerlessFramework CLI ourselves |

<img width="1438" alt="Screen Shot 2021-10-21 at 11 24 08" src="https://user-images.githubusercontent.com/2164346/138200384-c3f19829-3ba6-4efa-8454-314f733223bc.png">


